### PR TITLE
MADE.NET preview upgrade for FluentValidation improvement

### DIFF
--- a/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
@@ -66,17 +66,17 @@
     <PackageReference Include="FluentValidation">
       <Version>10.4.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview1</Version>
+      <Version>1.6.0-preview2</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>

--- a/samples/MADE.Samples/MADE.Samples.Shared/Features/Samples/Assets/InputValidator/InputValidatorFluentValidationCode.txt
+++ b/samples/MADE.Samples/MADE.Samples.Shared/Features/Samples/Assets/InputValidator/InputValidatorFluentValidationCode.txt
@@ -6,7 +6,7 @@ public string FluentValidationInputText
     set => this.SetProperty(ref fluentValidationInputText, value);
 }
 
-private static IEnumerable<AbstractValidator<string>> GetFluentValidators()
+private static IEnumerable<IValidator<string>> GetFluentValidators()
 {
     var requiredValidator = new InlineValidator<string>();
     requiredValidator

--- a/samples/MADE.Samples/MADE.Samples.Shared/Features/Samples/ViewModels/InputValidatorPageViewModel.cs
+++ b/samples/MADE.Samples/MADE.Samples.Shared/Features/Samples/ViewModels/InputValidatorPageViewModel.cs
@@ -49,7 +49,7 @@ namespace MADE.Samples.Features.Samples.ViewModels
             set => this.SetProperty(ref fluentValidationInputText, value);
         }
 
-        private static IEnumerable<AbstractValidator<string>> GetFluentValidators()
+        private static IEnumerable<IValidator<string>> GetFluentValidators()
         {
             var requiredValidator = new InlineValidator<string>();
             requiredValidator

--- a/samples/MADE.Samples/MADE.Samples.UWP/MADE.Samples.UWP.csproj
+++ b/samples/MADE.Samples/MADE.Samples.UWP/MADE.Samples.UWP.csproj
@@ -11,17 +11,17 @@
     <PackageReference Include="FluentValidation">
       <Version>10.4.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview1</Version>
+      <Version>1.6.0-preview2</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>

--- a/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
@@ -43,15 +43,15 @@
     <!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation.FluentValidation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation.FluentValidation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />

--- a/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
+++ b/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
@@ -121,17 +121,17 @@
     <PackageReference Include="FluentValidation">
       <Version>10.4.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview1</Version>
+      <Version>1.6.0-preview2</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>

--- a/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
+++ b/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview1" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
+++ b/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
+++ b/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Data.Converters/MADE.UI.Data.Converters.csproj
+++ b/src/MADE.UI.Data.Converters/MADE.UI.Data.Converters.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Styling/MADE.UI.Styling.csproj
+++ b/src/MADE.UI.Styling/MADE.UI.Styling.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.ViewManagement/MADE.UI.ViewManagement.csproj
+++ b/src/MADE.UI.ViewManagement/MADE.UI.ViewManagement.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview1" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide a description below of the changes made and how it has been tested -->

Small change to the MADE.NET preview version to allow for the FluentValidatorCollection to be initialized with the IValidator interface rather than the abstract class implementation.

## PR checklist

- [x] Samples have been added/updated (where applicable)
- [ ] Tests have been added/updated (where applicable) and pass
- [x] Documentation has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
