### PR TITLE
Updated MADE.NET and Uno Platform to latest stable release

### DIFF
--- a/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Droid/MADE.Samples.Droid.csproj
@@ -64,19 +64,19 @@
       <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="FluentValidation">
-      <Version>10.4.0</Version>
+      <Version>11.0.1</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview2</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>
@@ -95,12 +95,12 @@
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives">
       <Version>7.1.11</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging">
-      <Version>4.2.6</Version>
+      <Version>4.3.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.35" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UniversalImageLoader" Version="1.9.36" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/MADE.Samples/MADE.Samples.UWP/MADE.Samples.UWP.csproj
+++ b/samples/MADE.Samples/MADE.Samples.UWP/MADE.Samples.UWP.csproj
@@ -9,19 +9,19 @@
       <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="FluentValidation">
-      <Version>10.4.0</Version>
+      <Version>11.0.1</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview2</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>
@@ -49,7 +49,7 @@
       <Version>4.0.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.UI">
-      <Version>4.2.6</Version>
+      <Version>4.3.6</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>

--- a/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
+++ b/samples/MADE.Samples/MADE.Samples.Wasm/MADE.Samples.Wasm.csproj
@@ -42,25 +42,25 @@
   <ItemGroup>
     <!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="7.1.2" />
-    <PackageReference Include="FluentValidation" Version="10.4.0" />
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation.FluentValidation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
+    <PackageReference Include="FluentValidation" Version="11.0.1" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation.FluentValidation" Version="1.6.0" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.0" />
     <PackageReference Include="Uno.ColorCode.UWP" Version="2.1.0-uno.36" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.3.0" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives" Version="7.1.11" />
-    <PackageReference Include="Uno.UI.WebAssembly" Version="4.2.6" />
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.2.6" />
+    <PackageReference Include="Uno.UI.WebAssembly" Version="4.3.6" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.3.6" />
     <PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
     <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="3.3.1" />
   </ItemGroup>

--- a/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
+++ b/samples/MADE.Samples/MADE.Samples.iOS/MADE.Samples.iOS.csproj
@@ -119,19 +119,19 @@
       <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="FluentValidation">
-      <Version>10.4.0</Version>
+      <Version>11.0.1</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
     <PackageReference Include="MADE.Data.Validation.FluentValidation">
-      <Version>1.6.0-preview2</Version>
+      <Version>1.6.0</Version>
     </PackageReference>
-    <PackageReference Include="MADE.Diagnostics" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Networking" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Runtime" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Threading" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Diagnostics" Version="1.6.0" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0" />
+    <PackageReference Include="MADE.Networking" Version="1.6.0" />
+    <PackageReference Include="MADE.Runtime" Version="1.6.0" />
+    <PackageReference Include="MADE.Threading" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>5.0.2</Version>
     </PackageReference>
@@ -145,16 +145,16 @@
       <Version>2.1.0-uno.36</Version>
     </PackageReference>
     <PackageReference Include="Uno.Extensions.Logging.OSLog">
-      <Version>1.3.0</Version>
+      <Version>1.4.0</Version>
     </PackageReference>
     <PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Primitives">
       <Version>7.1.11</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging">
-      <Version>4.2.6</Version>
+      <Version>4.3.6</Version>
     </PackageReference>
-    <PackageReference Include="Uno.UI.RemoteControl" Version="4.2.6" Condition="'$(Configuration)'=='Debug'" />
+    <PackageReference Include="Uno.UI.RemoteControl" Version="4.3.6" Condition="'$(Configuration)'=='Debug'" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">

--- a/src/MADE.Media.Image/MADE.Media.Image.csproj
+++ b/src/MADE.Media.Image/MADE.Media.Image.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
     <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
   </ItemGroup>
 

--- a/src/MADE.UI.Controls.ChipBox/MADE.UI.Controls.ChipBox.csproj
+++ b/src/MADE.UI.Controls.ChipBox/MADE.UI.Controls.ChipBox.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
+++ b/src/MADE.UI.Controls.DropDownList/MADE.UI.Controls.DropDownList.csproj
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Collections" Version="1.6.0-preview2" />
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Collections" Version="1.6.0" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
+++ b/src/MADE.UI.Controls.FilePicker/MADE.UI.Controls.FilePicker.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.RichEditToolbar/MADE.UI.Controls.RichEditToolbar.csproj
+++ b/src/MADE.UI.Controls.RichEditToolbar/MADE.UI.Controls.RichEditToolbar.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Controls.RichEditToolbar/RichEditToolbar.cs
+++ b/src/MADE.UI.Controls.RichEditToolbar/RichEditToolbar.cs
@@ -4,6 +4,7 @@
 namespace MADE.UI.Controls
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Automation.Peers;
     using Windows.UI.Xaml.Controls;
@@ -82,6 +83,7 @@ namespace MADE.UI.Controls
         /// </summary>
         protected override void OnApplyTemplate()
         {
+            this.ResetCustomOptions();
             this.ResetFontSizeOptions();
             this.ResetFontStyleOptions();
             this.ResetTextColorOptions();
@@ -161,6 +163,22 @@ namespace MADE.UI.Controls
                 if (!this.Toolbar.PrimaryCommands.Contains(option))
                 {
                     this.Toolbar.PrimaryCommands.Add(option);
+                }
+            }
+        }
+
+        private void ResetCustomOptions()
+        {
+            if (this.Toolbar == null || this.CustomOptions == null)
+            {
+                return;
+            }
+
+            foreach (var option in this.CustomOptions)
+            {
+                if (this.Toolbar.PrimaryCommands.Contains(option))
+                {
+                    this.Toolbar.PrimaryCommands.Remove(option);
                 }
             }
         }

--- a/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
+++ b/src/MADE.UI.Controls.Validator/MADE.UI.Controls.Validator.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Data.Converters/MADE.UI.Data.Converters.csproj
+++ b/src/MADE.UI.Data.Converters/MADE.UI.Data.Converters.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Converters" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Converters" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Styling/MADE.UI.Styling.csproj
+++ b/src/MADE.UI.Styling/MADE.UI.Styling.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Data.Validation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Data.Validation" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.ViewManagement/MADE.UI.ViewManagement.csproj
+++ b/src/MADE.UI.ViewManagement/MADE.UI.ViewManagement.csproj
@@ -14,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MADE.Foundation" Version="1.6.0-preview2" />
+    <PackageReference Include="MADE.Foundation" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Views.Dialogs/MADE.UI.Views.Dialogs.csproj
+++ b/src/MADE.UI.Views.Dialogs/MADE.UI.Views.Dialogs.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Views.Navigation.Mvvm/MADE.UI.Views.Navigation.Mvvm.csproj
+++ b/src/MADE.UI.Views.Navigation.Mvvm/MADE.UI.Views.Navigation.Mvvm.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI.Views.Navigation/MADE.UI.Views.Navigation.csproj
+++ b/src/MADE.UI.Views.Navigation/MADE.UI.Views.Navigation.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MADE.UI/MADE.UI.csproj
+++ b/src/MADE.UI/MADE.UI.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == '.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
-    <PackageReference Include="Uno.UI" Version="4.2.6" />
+    <PackageReference Include="Uno.UI" Version="4.3.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Fixes #82
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Changes have been made to rev the NuGet package dependencies for MADE.NET to the stable 1.6.0 version which includes FluentValidation support for the `InputValidator`.

Also includes updates for the @unoplatform packages to 4.3 🎉

## PR checklist

- [x] Samples have been added/updated (where applicable)
- [x] Tests have been added/updated (where applicable) and pass
- [ ] Documentation has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
