### PR TITLE
#66 - Added change to ensure that custom options for RichEditToolbar are cleared properly

### DIFF
--- a/src/MADE.UI.Controls.RichEditToolbar/RichEditToolbar.cs
+++ b/src/MADE.UI.Controls.RichEditToolbar/RichEditToolbar.cs
@@ -51,6 +51,7 @@ namespace MADE.UI.Controls
         public RichEditToolbar()
         {
             this.DefaultStyleKey = typeof(RichEditToolbar);
+            this.Unloaded += OnUnloaded;
         }
 
 #if WINDOWS_UWP
@@ -165,6 +166,16 @@ namespace MADE.UI.Controls
                     this.Toolbar.PrimaryCommands.Add(option);
                 }
             }
+        }
+
+        private void OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            this.ClearCustomOptions();
+        }
+
+        private void ClearCustomOptions()
+        {
+            this.CustomOptions?.Clear();
         }
 
         private void ResetCustomOptions()


### PR DESCRIPTION
## Fixes #66
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Added minor change to the `RichEditToolbar` to unload custom options correctly.

## PR checklist

- [x] Samples have been added/updated (where applicable)
- [ ] Tests have been added/updated (where applicable) and pass
- [ ] Documentation has been added/updated for changes
- [x] Code styling has been met on new source file changes
- [x] Contains **NO** breaking changes

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Please provide any additional information, links, or screenshots below if applicable -->
